### PR TITLE
Allow configuration of the request timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,15 @@ A [Speedtest](https://www.speedtest.net) exporter for Prometheus.
 
 ```bash
 $ ./speedtest_exporter --help
-Usage of speedtest_exporter
+Usage of speedtest_exporter:
   -port string
         listening port to expose metrics on (default "9090")
   -server_fallback
-        If the serverID given is not available, should we fallback to closest available server
+        If the server_id given is not available, should we fallback to closest available server
   -server_id int
         Speedtest.net server ID to run test against, -1 will pick the closest server to your location (default -1)
+  -timeout int
+        request timeout for the execution of the speedtest (default 60)
 
 ```
 

--- a/cmd/speedtest_exporter/main.go
+++ b/cmd/speedtest_exporter/main.go
@@ -20,6 +20,7 @@ func main() {
 	port := flag.String("port", "9090", "listening port to expose metrics on")
 	serverID := flag.Int("server_id", -1, "Speedtest.net server ID to run test against, -1 will pick the closest server to your location")
 	serverFallback := flag.Bool("server_fallback", false, "If the server_id given is not available, should we fallback to closest available server")
+	requestTimeout := flag.Int("timeout", 60, "request timeout for the execution of the speedtest")
 	flag.Parse()
 
 	exporter, err := exporter.New(*serverID, *serverFallback)
@@ -58,7 +59,9 @@ func main() {
 
 	http.Handle(metricsPath, promhttp.HandlerFor(r, promhttp.HandlerOpts{
 		MaxRequestsInFlight: 1,
-		Timeout:             60 * time.Second,
+		Timeout:             time.Duration(*requestTimeout) * time.Second,
 	}))
+
+	log.Info("starting listener on port: " + *port)
 	log.Fatal(http.ListenAndServe(":"+*port, nil))
 }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

The timeout of 60s was a bit too short for my internet or the used servers, sometimes my speedtest ran into a timeout. I added a configurable parameter to be able to increase the timeout.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have updated the documentation accordingly.
- [x] All commits are GPG signed
